### PR TITLE
Add basic player rigs and a few other tweaks

### DIFF
--- a/player_rigs/dynamic_player_rig.gd
+++ b/player_rigs/dynamic_player_rig.gd
@@ -1,0 +1,136 @@
+@tool
+extends XROrigin3D
+class_name XRT2DynamicPlayerRig
+
+## This player rig is meant for games where the player can move around
+
+
+var _start_xr : XRT2StartXR
+var _player_is_colliding :bool = false
+
+# Node helpers
+@onready var _xr_camera : XRCamera3D = $XRCamera3D
+@onready var _neck_position : Node3D = $XRCamera3D/Neck
+@onready var _fade : Node3D = $XRCamera3D/Fade
+
+
+## Returns true if the player has physically moved into a place where they
+## are colliding with the environment.
+## (e.g. we can't move our character body where the player is standing)
+##
+## You should check this before enabling user input movement.
+func get_player_is_colliding() -> bool:
+	return _player_is_colliding
+
+
+# User triggered pose recenter.
+func _on_xr_pose_recenter() -> void:
+	if not _start_xr:
+		# Huh? how did we even get the signal?
+		return
+
+	var play_area_mode : XRInterface.PlayAreaMode = _start_xr.get_play_area_mode()
+	if play_area_mode == XRInterface.XR_PLAY_AREA_SITTING:
+		# Using center on HMD could mess things up here
+		push_warning("Dynamic  player rig does not work with sitting setting")
+	elif play_area_mode == XRInterface.XR_PLAY_AREA_ROOMSCALE:
+		# This is already handled by the headset, no need to do more!
+		pass
+	else:
+		XRServer.center_on_hmd(XRServer.RESET_BUT_KEEP_TILT, true)
+
+	# Reset our XROrigin transform
+	# TODO: adjust this ever so slightly based on neck position 
+	transform = Transform3D()
+
+	# TODO: we may want to trigger re-orienting our parent in a fixed direction.
+
+
+# Verifies our staging has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := PackedStringArray()
+
+	# Check if parent is of the correct type
+	var parent = get_parent()
+	if parent and not parent is CharacterBody3D:
+		warnings.append("Parent node must be a CharacterBody3D")
+
+	# TODO: add config warning if we're set to Local Floor
+
+	# Return warnings
+	return warnings
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	# Do not run if in the editor
+	if Engine.is_editor_hint():
+		return
+
+	_start_xr = XRT2StartXR.get_singleton()
+	if _start_xr:
+		_start_xr.xr_pose_recenter.connect(_on_xr_pose_recenter)
+
+
+func _exit_tree():
+	if _start_xr:
+		_start_xr.xr_pose_recenter.disconnect(_on_xr_pose_recenter)
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _physics_process(delta):
+	# Do not run if in the editor
+	if Engine.is_editor_hint():
+		set_physics_process(false)
+		return
+
+	# Process our physical movement, input movement is handled on the parent node.
+	var parent : CharacterBody3D = get_parent()
+	if not parent:
+		push_warning("Parent node isn't a CharacterBody3D node, dynamic player rig is disabled!")
+		set_physics_process(false)
+		return
+
+	# Remember our current velocity, we'll apply that later
+	var current_velocity = parent.velocity
+
+	# Start by rotating the player to face the same way our real player is
+	var camera_basis: Basis = transform.basis * _xr_camera.transform.basis
+	var forward: Vector2 = Vector2(camera_basis.z.x, camera_basis.z.z)
+	var angle: float = forward.angle_to(Vector2(0.0, 1.0))
+
+	# Rotate our character body
+	parent.transform.basis = parent.transform.basis.rotated(Vector3.UP, angle)
+
+	# Reverse this rotation our origin node
+	transform = Transform3D().rotated(Vector3.UP, -angle) * transform
+
+	# Now apply movement, first move our player body to the right location
+	var org_player_body: Vector3 = parent.global_transform.origin
+	var player_body_location: Vector3 = transform * _xr_camera.transform * _neck_position.transform.origin
+	player_body_location.y = 0.0
+	player_body_location = parent.global_transform * player_body_location
+
+	parent.velocity = (player_body_location - org_player_body) / delta
+	parent.move_and_slide()
+
+	# Now move our XROrigin back
+	var delta_movement = parent.global_transform.origin - org_player_body
+	global_transform.origin -= delta_movement
+
+	# Negate any height change in local space due to player hitting ramps etc.
+	transform.origin.y = 0.0
+
+	# Return our value
+	parent.velocity = current_velocity
+
+	# Check if we managed to move where we wanted to
+	var location_offset = (player_body_location - parent.global_transform.origin).length()
+	if location_offset > 0.1:
+		# We couldn't go where we wanted to, black out our screen
+		_fade.fade = clamp((location_offset - 0.1) / 0.1, 0.0, 1.0)
+
+		_player_is_colliding = true
+	else:
+		_fade.fade = 0.0
+		_player_is_colliding = false	

--- a/player_rigs/dynamic_player_rig.tscn
+++ b/player_rigs/dynamic_player_rig.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=3 format=3 uid="uid://cynxxfm8nksg4"]
+
+[ext_resource type="Script" path="res://addons/godot-xr-tools2/player_rigs/dynamic_player_rig.gd" id="1_2824a"]
+[ext_resource type="PackedScene" uid="uid://dxvyqip0j4gdj" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.tscn" id="2_awihb"]
+
+[node name="DynamicPlayerRig" type="XROrigin3D"]
+script = ExtResource("1_2824a")
+
+[node name="XRCamera3D" type="XRCamera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.7, 0)
+
+[node name="Neck" type="Node3D" parent="XRCamera3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.1, 0.1)
+
+[node name="Fade" parent="XRCamera3D" instance=ExtResource("2_awihb")]
+
+[node name="LeftHand" type="XRController3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 1, -0.5)
+tracker = &"left_hand"
+show_when_tracked = true
+
+[node name="RightHand" type="XRController3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5)
+tracker = &"right_hand"
+show_when_tracked = true

--- a/player_rigs/static_player_rig.gd
+++ b/player_rigs/static_player_rig.gd
@@ -1,0 +1,55 @@
+extends XROrigin3D
+class_name XRT2StaticPlayerRig
+
+## This player rig is meant for simulation games such as driving games
+## or flight simulation.
+## It is designed on the assumption this node is placed where the players
+## head should be by default.
+
+
+## Maximum distance the players head can be from the origin point before we fade to black.
+@onready var max_head_distance : float = 0.5
+@onready var fade_distance : float = 0.1
+
+
+var _start_xr : XRT2StartXR
+
+# Node helpers
+@onready var _xr_camera : XRCamera3D = $XRCamera3D
+@onready var _fade : XRT2EffectFade = $XRCamera3D/Fade
+
+
+# User triggered pose recenter.
+func _on_xr_pose_recenter() -> void:
+	if not _start_xr:
+		# Huh? how did we even get the signal?
+		return
+
+	var play_area_mode : XRInterface.PlayAreaMode = _start_xr.get_play_area_mode()
+	if play_area_mode == XRInterface.XR_PLAY_AREA_SITTING:
+		# This is already handled by the headset, no need to do more!
+		pass
+	elif play_area_mode == XRInterface.XR_PLAY_AREA_ROOMSCALE:
+		# Using center on HMD could mess things up here
+		push_warning("Static player rig does not work with roomscale setting")
+	else:
+		XRServer.center_on_hmd(XRServer.RESET_BUT_KEEP_TILT, false)
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	_start_xr = XRT2StartXR.get_singleton()
+	if _start_xr:
+		_start_xr.xr_pose_recenter.connect(_on_xr_pose_recenter)
+
+
+func _exit_tree():
+	if _start_xr:
+		_start_xr.xr_pose_recenter.disconnect(_on_xr_pose_recenter)
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	var distance = _xr_camera.position.length()
+	if distance > max_head_distance:
+		_fade.fade = clamp((distance - max_head_distance) / fade_distance, 0.0, 1.0)

--- a/player_rigs/static_player_rig.tscn
+++ b/player_rigs/static_player_rig.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=3 format=3 uid="uid://y1mt4vculye7"]
+
+[ext_resource type="Script" path="res://addons/godot-xr-tools2/player_rigs/static_player_rig.gd" id="1_v7cup"]
+[ext_resource type="PackedScene" uid="uid://dxvyqip0j4gdj" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.tscn" id="2_0btq6"]
+
+[node name="StaticPlayerRig" type="XROrigin3D"]
+script = ExtResource("1_v7cup")
+
+[node name="XRCamera3D" type="XRCamera3D" parent="."]
+
+[node name="Fade" parent="XRCamera3D" instance=ExtResource("2_0btq6")]
+message = "Please recenter your tracking space."
+
+[node name="LeftHand" type="XRController3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, -0.5, -0.5)
+tracker = &"left_hand"
+show_when_tracked = true
+
+[node name="RightHand" type="XRController3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, -0.5, -0.5)
+tracker = &"right_hand"
+show_when_tracked = true

--- a/staging/base_stages/xrt2_stage_base.gd
+++ b/staging/base_stages/xrt2_stage_base.gd
@@ -20,12 +20,36 @@ signal request_load_scene(p_scene_path, user_data)
 ## The [param user_data] parameter is passed through staging to the new scenes.
 signal request_reset_scene(user_data)
 
+
+## Player origin used in this stage
+@export var player_origin : XROrigin3D
+
+var _camera : XRCamera3D
+
 # TODO update documentation for entry points, there are differences with how 
 # this worked in XR Tools 2 around centering the player
 
+# Verifies our staging has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := PackedStringArray()
+
+	# Report player origin not specified
+	if not player_origin:
+		warnings.append("No player origin has been selected")
+
+	# Return warnings
+	return warnings
+
+
 ## This is called after the scene is loaded and added to our scene tree
 func scene_loaded(user_data = null) -> void:
-	pass
+	# Make our camera current
+	if _camera:
+		_camera.current = true
+
+	# Make our origin current
+	if player_origin:
+		player_origin.current = true
 
 
 ## This is called once our scene has become fully visible
@@ -40,11 +64,6 @@ func scene_pre_exiting(user_data = null) -> void:
 
 ## This is called just before our scene is removed from the scene tree
 func scene_exiting(user_data = null) -> void:
-	pass
-
-
-## This is called when the user has requested to recenter the player
-func pose_recenter() -> void:
 	pass
 
 
@@ -64,4 +83,12 @@ func reset_scene(user_data = null) -> void:
 
 
 func _ready() -> void:
-	pass
+	# Do not run if in the editor
+	if Engine.is_editor_hint():
+		return
+
+	if player_origin:
+		for child in player_origin.get_children():
+			if child is XRCamera3D:
+				_camera = child
+				break

--- a/staging/loading_screen/xrt2_loading_screen.gd
+++ b/staging/loading_screen/xrt2_loading_screen.gd
@@ -57,6 +57,13 @@ var _spinning_logo_material : ShaderMaterial
 		if is_inside_tree():
 			_update_press_to_continue()
 
+
+@export var activate_action : String = "trigger_click":
+	set(value):
+		activate_action = value
+		if is_inside_tree():
+			_update_activate_action()
+
 const SPIN_SPEED = 2.0
 var spinning_logo_angle = 0.0
 
@@ -75,11 +82,15 @@ func _update_progress_bar() -> void:
 
 
 func _update_press_to_continue() -> void:
-	if is_inside_tree():
-		# _progress_bar.visible = !enable_press_to_continue
-		_spinning_logo.visible = !enable_press_to_continue
-		_press_to_continue.visible = enable_press_to_continue
-		_hold_button.enabled = enable_press_to_continue
+	# _progress_bar.visible = !enable_press_to_continue
+	_spinning_logo.visible = !enable_press_to_continue
+	_press_to_continue.visible = enable_press_to_continue
+	_hold_button.enabled = enable_press_to_continue
+
+
+func _update_activate_action() -> void:
+	if not Engine.is_editor_hint():
+		_hold_button.activate_action = activate_action
 
 
 # Called when the node enters the scene tree for the first time.
@@ -92,6 +103,7 @@ func _ready() -> void:
 	_update_spinning_logo()
 	_update_progress_bar()
 	_update_press_to_continue()
+	_update_activate_action()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/staging/loading_screen/xrt2_loading_screen.tscn
+++ b/staging/loading_screen/xrt2_loading_screen.tscn
@@ -43,19 +43,20 @@ size = Vector2(3, 3)
 script = ExtResource("1_ugti3")
 follow_speed = SubResource("Curve_ve03c")
 spinning_logo = ExtResource("2_y53v2")
+activate_action = null
 
 [node name="SplashScreen" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 15, -50)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 15, -75)
 material_override = SubResource("ShaderMaterial_juqya")
 mesh = SubResource("QuadMesh_d472w")
 
 [node name="SpinningLogo" type="MeshInstance3D" parent="."]
-transform = Transform3D(0.706602, 0, 0.707612, 0, 1, 0, -0.707612, 0, 0.706602, 9.6923, 0, -10)
+transform = Transform3D(-0.154862, 0, -0.987937, 0, 1, 0, 0.987937, 0, -0.154862, 9.692, 0, -15)
 material_override = SubResource("ShaderMaterial_ycls2")
 mesh = SubResource("QuadMesh_rkvh4")
 
 [node name="PressToContinue" type="Label3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -15)
 visible = false
 pixel_size = 0.05
 text = "Hold button to continue	"


### PR DESCRIPTION
Add the initial player rigs. We have two.

Static player rig is for experiences where the game character is sitting down (driving simulations, flight simulations etc)

Dynamic player rig is for experiences where the game character can walk around. There is a departure here from how we did things in XR Tools. This new rig is character body centric however the character body and its collision shape are not part of the rig. It is enforced that this rig is added to a character body.
The rig handles physical movement by the player, while input movement should be handled by a script on the character body.