### PR TITLE
Fix UID values to prevent clashes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
         language: python
         entry: python misc/workflow_scripts/copyright_headers.py
         files: \.(gd)$
+      - id: uid-checks
+        name: uid-checks
+        language: python
+        entry: python misc/workflow_scripts/uid_checks.py
+        files: \.(tscn|import|tres)$

--- a/components/xrt2_2d_ui.tscn
+++ b/components/xrt2_2d_ui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://bc6kket4vsy0r"]
+[gd_scene load_steps=2 format=3 uid="uid://xrt200000013"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/components/xrt2_2d_ui.gd" id="1_icl45"]
 

--- a/effects/fade/xrt2_fade.tscn
+++ b/effects/fade/xrt2_fade.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://dxvyqip0j4gdj"]
+[gd_scene load_steps=5 format=3 uid="uid://xrt200000005"]
 
 [ext_resource type="Shader" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.gdshader" id="1_kocuh"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.gd" id="1_y1bfr"]

--- a/icon.png.import
+++ b/icon.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://d5sknr112aih"
+uid="uid://xrt200000001"
 path.s3tc="res://.godot/imported/icon.png-50cacf8bcdb55c573a184e40f8020e2a.s3tc.ctex"
 path.etc2="res://.godot/imported/icon.png-50cacf8bcdb55c573a184e40f8020e2a.etc2.ctex"
 metadata={

--- a/misc/workflow_scripts/uid_checks.py
+++ b/misc/workflow_scripts/uid_checks.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import re
+
+if len(sys.argv) < 2:
+    print("Invalid usage of copyright_headers.py, it should be called with a path to one or multiple files.")
+    sys.exit(1)
+
+for f in sys.argv[1:]:
+    fname = f
+    text = ""
+
+    pattern = re.compile(r'uid://[0-9a-z]+')
+
+    with open(fname.strip(), "r", encoding="utf-8") as fileread:
+        line = fileread.readline()
+
+        while line != "":  # Dump everything until EOF
+            for (uid) in re.findall(pattern, line):
+             fix = "uid://xrt2" + uid[10:18]
+             line = line.replace(uid, fix)
+
+            text += line
+            line = fileread.readline()
+
+    # Write
+    with open(fname.strip(), "w", encoding="utf-8", newline="\n") as filewrite:
+        filewrite.write(text)

--- a/player_rigs/xrt2_dynamic_player_rig.tscn
+++ b/player_rigs/xrt2_dynamic_player_rig.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://cynxxfm8nksg4"]
+[gd_scene load_steps=3 format=3 uid="uid://xrt200000009"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/player_rigs/xrt2_dynamic_player_rig.gd" id="1_2824a"]
-[ext_resource type="PackedScene" uid="uid://dxvyqip0j4gdj" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.tscn" id="2_awihb"]
+[ext_resource type="PackedScene" uid="uid://xrt200000005" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.tscn" id="2_awihb"]
 
 [node name="DynamicPlayerRig" type="XROrigin3D"]
 script = ExtResource("1_2824a")

--- a/player_rigs/xrt2_player_character.tscn
+++ b/player_rigs/xrt2_player_character.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://bq5rgapu8u4xk"]
+[gd_scene load_steps=4 format=3 uid="uid://xrt200000012"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/player_rigs/xrt2_player_character.gd" id="1_htswx"]
-[ext_resource type="PackedScene" uid="uid://cynxxfm8nksg4" path="res://addons/godot-xr-tools2/player_rigs/xrt2_dynamic_player_rig.tscn" id="2_22tak"]
+[ext_resource type="PackedScene" uid="uid://xrt200000009" path="res://addons/godot-xr-tools2/player_rigs/xrt2_dynamic_player_rig.tscn" id="2_22tak"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_v62os"]
 radius = 0.3

--- a/player_rigs/xrt2_static_player_rig.tscn
+++ b/player_rigs/xrt2_static_player_rig.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://y1mt4vculye7"]
+[gd_scene load_steps=3 format=3 uid="uid://xrt200000008"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/player_rigs/xrt2_static_player_rig.gd" id="1_v7cup"]
-[ext_resource type="PackedScene" uid="uid://dxvyqip0j4gdj" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.tscn" id="2_0btq6"]
+[ext_resource type="PackedScene" uid="uid://xrt200000005" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.tscn" id="2_0btq6"]
 
 [node name="StaticPlayerRig" type="XROrigin3D"]
 script = ExtResource("1_v7cup")

--- a/staging/base_stages/xrt2_default_environment.tres
+++ b/staging/base_stages/xrt2_default_environment.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Environment" load_steps=3 format=3 uid="uid://b2l51i561qe83"]
+[gd_resource type="Environment" load_steps=3 format=3 uid="uid://xrt200000002"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_gl6tr"]
 

--- a/staging/base_stages/xrt2_stage_base.tscn
+++ b/staging/base_stages/xrt2_stage_base.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://cl352deej8d8f"]
+[gd_scene load_steps=3 format=3 uid="uid://xrt200000007"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/staging/base_stages/xrt2_stage_base.gd" id="1_vdt8w"]
-[ext_resource type="Environment" uid="uid://b2l51i561qe83" path="res://addons/godot-xr-tools2/staging/base_stages/xrt2_default_environment.tres" id="2_jqa2c"]
+[ext_resource type="Environment" uid="uid://xrt200000002" path="res://addons/godot-xr-tools2/staging/base_stages/xrt2_default_environment.tres" id="2_jqa2c"]
 
 [node name="Xrt2SceneBase" type="Node3D"]
 script = ExtResource("1_vdt8w")

--- a/staging/loading_screen/xrt2_loading_screen.tscn
+++ b/staging/loading_screen/xrt2_loading_screen.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=13 format=3 uid="uid://j2dmckl6eh61"]
+[gd_scene load_steps=13 format=3 uid="uid://xrt200000004"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/staging/loading_screen/xrt2_loading_screen.gd" id="1_ugti3"]
-[ext_resource type="PackedScene" uid="uid://c0osfqxwvi7ko" path="res://addons/godot-xr-tools2/ui/buttons/xrt2_hold_button.tscn" id="2_m02j3"]
-[ext_resource type="Texture2D" uid="uid://d5sknr112aih" path="res://addons/godot-xr-tools2/icon.png" id="2_y53v2"]
+[ext_resource type="PackedScene" uid="uid://xrt200000011" path="res://addons/godot-xr-tools2/ui/buttons/xrt2_hold_button.tscn" id="2_m02j3"]
+[ext_resource type="Texture2D" uid="uid://xrt200000001" path="res://addons/godot-xr-tools2/icon.png" id="2_y53v2"]
 [ext_resource type="Shader" path="res://addons/godot-xr-tools2/shaders/unshaded_texture_with_alpha.gdshader" id="4_pjv7i"]
 
 [sub_resource type="Curve" id="Curve_ve03c"]
@@ -66,7 +66,7 @@ material_override = SubResource("ShaderMaterial_juqya")
 mesh = SubResource("QuadMesh_d472w")
 
 [node name="SpinningLogo" type="MeshInstance3D" parent="."]
-transform = Transform3D(0.839271, 0, -0.543714, 0, 1, 0, 0.543714, 0, 0.839271, 6, -3, -10)
+transform = Transform3D(-0.111994, 0, -0.993709, 0, 1, 0, 0.993709, 0, -0.111994, 6, -3, -10)
 material_override = SubResource("ShaderMaterial_ycls2")
 mesh = SubResource("QuadMesh_rkvh4")
 

--- a/staging/xrt2_staging.tscn
+++ b/staging/xrt2_staging.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://8sqqx5gxegw7"]
+[gd_scene load_steps=6 format=3 uid="uid://xrt200000006"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/staging/xrt2_staging.gd" id="1_ap58f"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/staging/xrt2_start_xr.gd" id="2_d55t1"]
-[ext_resource type="PackedScene" uid="uid://dxvyqip0j4gdj" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.tscn" id="2_mnsfb"]
-[ext_resource type="PackedScene" uid="uid://j2dmckl6eh61" path="res://addons/godot-xr-tools2/staging/loading_screen/xrt2_loading_screen.tscn" id="3_5dvaj"]
-[ext_resource type="Environment" uid="uid://d12ro1nqqnic1" path="res://addons/godot-xr-tools2/staging/xrt2_staging_environment.tres" id="3_7oin8"]
+[ext_resource type="PackedScene" uid="uid://xrt200000005" path="res://addons/godot-xr-tools2/effects/fade/xrt2_fade.tscn" id="2_mnsfb"]
+[ext_resource type="PackedScene" uid="uid://xrt200000004" path="res://addons/godot-xr-tools2/staging/loading_screen/xrt2_loading_screen.tscn" id="3_5dvaj"]
+[ext_resource type="Environment" uid="uid://xrt200000003" path="res://addons/godot-xr-tools2/staging/xrt2_staging_environment.tres" id="3_7oin8"]
 
 [node name="Xrt2Staging" type="Node3D"]
 script = ExtResource("1_ap58f")

--- a/staging/xrt2_staging_environment.tres
+++ b/staging/xrt2_staging_environment.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Environment" format=3 uid="uid://d12ro1nqqnic1"]
+[gd_resource type="Environment" format=3 uid="uid://xrt200000003"]
 
 [resource]
 background_mode = 1

--- a/ui/buttons/xrt2_hold_button.tscn
+++ b/ui/buttons/xrt2_hold_button.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://c0osfqxwvi7ko"]
+[gd_scene load_steps=5 format=3 uid="uid://xrt200000011"]
 
-[ext_resource type="Shader" uid="uid://ntq5rgbft3mu" path="res://addons/godot-xr-tools2/ui/buttons/xrt2_hold_button_visualshader.tres" id="1_7ops6"]
+[ext_resource type="Shader" uid="uid://xrt200000010" path="res://addons/godot-xr-tools2/ui/buttons/xrt2_hold_button_visualshader.tres" id="1_7ops6"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools2/ui/buttons/xrt2_hold_button.gd" id="1_ir5oa"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_hl8u4"]

--- a/ui/buttons/xrt2_hold_button_visualshader.tres
+++ b/ui/buttons/xrt2_hold_button_visualshader.tres
@@ -1,4 +1,4 @@
-[gd_resource type="VisualShader" load_steps=28 format=3 uid="uid://ntq5rgbft3mu"]
+[gd_resource type="VisualShader" load_steps=28 format=3 uid="uid://xrt200000010"]
 
 [sub_resource type="VisualShaderNodeFloatOp" id="1"]
 output_port_for_preview = 0
@@ -253,7 +253,6 @@ void fragment() {
 
 }
 "
-graph_offset = Vector2(-366.592, -225.773)
 flags/unshaded = true
 nodes/fragment/0/position = Vector2(1800, -40)
 nodes/fragment/2/node = SubResource("3")


### PR DESCRIPTION
UIDs are int64 values stored in base36. They are random generated by Godot so files can be tracked when moved around the system.

The problem with this is that when you copy files, which we often do as we add files from XR Tools 1 before modifying them, we get the UIDs copied over from their source.

In scenarios where a user wants to migrate from XR tools 1 to XR tools 2 and temporarily adds both libraries to the same source, this duplication results in mayhem and a fully broken project.

To counter this we're going to enforce UIDs are all prefixed with `xrt2` and we assign a unique number ourselves. This PR applies that to existing classes, and adds a guard to prevent merging UIDs we haven't updated.