### PR TITLE
Add a spectator camera in PCVR mode

### DIFF
--- a/construct/xrt2_construct.gd
+++ b/construct/xrt2_construct.gd
@@ -1,0 +1,64 @@
+#-------------------------------------------------------------------------------
+# xrt2_construct.gd
+#-------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2024-present Bastiaan Olij, Malcolm A Nixon and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#-------------------------------------------------------------------------------
+
+class_name XRT2Construct
+extends Node2D
+
+
+@export_range(20, 200, 1) var throttle_desktop_fps : int = 30
+
+var _throttle : float = 0.0
+
+# Resize our viewport container to match our window size
+func _on_size_changed() -> void:
+	# Get the new size of our window
+	var window_size  = get_tree().get_root().size
+
+	# Set our container to full screen, this should update our viewport
+	$DesktopContainer.size = window_size
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	# Make sure our main viewport doesn't render 3D
+	var vp = get_viewport()
+	vp.disable_3d = true
+
+	# Get a signal when our window size changes
+	get_tree().get_root().size_changed.connect(_on_size_changed)
+
+	# Call atleast once to initialise
+	_on_size_changed()
+
+
+# Called every frame
+func _process(delta):
+	_throttle -= delta
+	if _throttle < 0.0:
+		# Trigger redraw
+		%DesktopSubViewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+
+		_throttle = max(0.0, _throttle + (1.0 / throttle_desktop_fps))

--- a/construct/xrt2_construct.gd.uid
+++ b/construct/xrt2_construct.gd.uid
@@ -1,0 +1,1 @@
+uid://xrt2cb81veb

--- a/construct/xrt2_construct.tscn
+++ b/construct/xrt2_construct.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=2 format=3 uid="uid://xrt2j78g3fc"]
+
+[ext_resource type="Script" uid="uid://xrt2cb81veb" path="res://addons/godot-xr-tools2/construct/xrt2_construct.gd" id="1_brwkg"]
+
+[node name="Xrt2Construct" type="Node2D"]
+script = ExtResource("1_brwkg")
+
+[node name="DesktopContainer" type="SubViewportContainer" parent="."]
+custom_minimum_size = Vector2(256, 128)
+offset_right = 40.0
+offset_bottom = 40.0
+stretch = true
+
+[node name="DesktopSubViewport" type="SubViewport" parent="DesktopContainer"]
+unique_name_in_owner = true
+handle_input_locally = false
+size = Vector2i(256, 128)
+render_target_update_mode = 4
+
+[node name="VRSubViewport" type="SubViewport" parent="."]
+unique_name_in_owner = true

--- a/construct/xrt2_spectator_camera.gd
+++ b/construct/xrt2_spectator_camera.gd
@@ -1,0 +1,86 @@
+#-------------------------------------------------------------------------------
+# xrt2_spectator_camera.gd
+#-------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2024-present Bastiaan Olij, Malcolm A Nixon and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#-------------------------------------------------------------------------------
+
+@tool
+extends Node3D
+
+## If [code]true[/code] the player wearing the headset can see the camera.
+## Disabling this doesn't effect the desktop view!
+@export var show_camera_in_hmd = true:
+	set(value):
+		show_camera_in_hmd = value
+		if is_inside_tree():
+			$SpectatorCamera3D/Camera.visible = show_camera_in_hmd
+
+
+# Material used to show viewport image
+var _material : ShaderMaterial
+
+# Viewport texture used to show viewport image
+var _viewport_texture : ViewportTexture
+
+# Display on which we show our viewport image
+@onready var _display : MeshInstance3D = $SpectatorCamera3D/Camera/CameraDisplay/Display
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	# Only do our layer checks, if in the editor
+	if Engine.is_editor_hint():
+		if ProjectSettings.get_setting("layer_names/3d_render/layer_2").is_empty():
+			ProjectSettings.set_setting("layer_names/3d_render/layer_2", "HMD only")
+
+		if ProjectSettings.get_setting("layer_names/3d_render/layer_3").is_empty():
+			ProjectSettings.set_setting("layer_names/3d_render/layer_3", "Spectator only")
+
+		return
+
+	$SpectatorCamera3D/Camera.visible = show_camera_in_hmd
+
+	var vp : Viewport = get_viewport()
+	_material = _display.material_override
+	if vp and _material:
+		_viewport_texture = vp.get_texture()
+		_material.set_shader_parameter("texture_albedo", _viewport_texture)
+
+
+# Called each frame
+func _process(_delta):
+	# Do not run if in the editor
+	if Engine.is_editor_hint():
+		return
+
+	if _viewport_texture and _display:
+		var size = _viewport_texture.get_size()
+
+		# Note: adjusting scale instead of mesh size
+		# prevents rebuilding a new mesh
+		var height : float = 0.18
+		var width : float = height * size.x / size.y
+		if width > 0.38:
+			width = 0.38
+			height = width * size.y / size.x
+		_display.scale = Vector3(width, height, 1.0)

--- a/construct/xrt2_spectator_camera.gd.uid
+++ b/construct/xrt2_spectator_camera.gd.uid
@@ -1,0 +1,1 @@
+uid://xrt2dafnu3w

--- a/construct/xrt2_spectator_camera.tscn
+++ b/construct/xrt2_spectator_camera.tscn
@@ -1,0 +1,72 @@
+[gd_scene load_steps=10 format=3 uid="uid://xrt23kyre42"]
+
+[ext_resource type="Script" uid="uid://xrt2dafnu3w" path="res://addons/godot-xr-tools2/construct/xrt2_spectator_camera.gd" id="1_dbds7"]
+[ext_resource type="Shader" uid="uid://xrt2oqik7ik" path="res://addons/godot-xr-tools2/shaders/shaded_no_alpha.gdshader" id="1_luqx8"]
+[ext_resource type="Shader" uid="uid://xrt2lfbdmdk" path="res://addons/godot-xr-tools2/shaders/unshaded_texture_no_alpha.gdshader" id="3_gcvm6"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_4ym2f"]
+render_priority = 0
+shader = ExtResource("1_luqx8")
+shader_parameter/albedo = Color(0.147672, 0.147672, 0.147672, 1)
+shader_parameter/metallic = 0.3
+shader_parameter/roughness = 0.8
+shader_parameter/specular = 0.5
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_dbds7"]
+top_radius = 0.1
+bottom_radius = 0.1
+height = 0.1
+
+[sub_resource type="BoxMesh" id="BoxMesh_brmuf"]
+size = Vector3(0.21, 0.25, 0.6)
+
+[sub_resource type="BoxMesh" id="BoxMesh_yqcti"]
+size = Vector3(0.4, 0.2, 0.05)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_0gxnl"]
+render_priority = 0
+shader = ExtResource("3_gcvm6")
+shader_parameter/albedo = Color(1, 1, 1, 1)
+shader_parameter/uv_scale = Vector2(1, 1)
+shader_parameter/uv_offset = Vector2(0, 0)
+
+[sub_resource type="QuadMesh" id="QuadMesh_impty"]
+
+[node name="Xrt2SpectatorCamera" type="Node3D"]
+script = ExtResource("1_dbds7")
+
+[node name="SpectatorCamera3D" type="Camera3D" parent="."]
+cull_mask = 1048573
+
+[node name="Camera" type="Node3D" parent="SpectatorCamera3D"]
+
+[node name="CameraLens" type="MeshInstance3D" parent="SpectatorCamera3D/Camera"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0.05)
+layers = 2
+material_override = SubResource("ShaderMaterial_4ym2f")
+cast_shadow = 0
+mesh = SubResource("CylinderMesh_dbds7")
+skeleton = NodePath("../..")
+
+[node name="CameraBody" type="MeshInstance3D" parent="SpectatorCamera3D/Camera"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.4)
+layers = 2
+material_override = SubResource("ShaderMaterial_4ym2f")
+cast_shadow = 0
+mesh = SubResource("BoxMesh_brmuf")
+skeleton = NodePath("../..")
+
+[node name="CameraDisplay" type="MeshInstance3D" parent="SpectatorCamera3D/Camera"]
+transform = Transform3D(0.980319, 0, 0.197418, 0, 1, 0, -0.197418, 0, 0.980319, 0.31924, 0, 0.157601)
+layers = 2
+material_override = SubResource("ShaderMaterial_4ym2f")
+cast_shadow = 0
+mesh = SubResource("BoxMesh_yqcti")
+skeleton = NodePath("../..")
+
+[node name="Display" type="MeshInstance3D" parent="SpectatorCamera3D/Camera/CameraDisplay"]
+transform = Transform3D(-0.38, 0, -1.50996e-07, 0, 0.18, 0, 5.73784e-08, 0, -1, 0.00580734, 0, -0.0288376)
+layers = 2
+material_override = SubResource("ShaderMaterial_0gxnl")
+cast_shadow = 0
+mesh = SubResource("QuadMesh_impty")

--- a/player_rigs/xrt2_dynamic_player_rig.tscn
+++ b/player_rigs/xrt2_dynamic_player_rig.tscn
@@ -8,6 +8,7 @@ script = ExtResource("1_2824a")
 
 [node name="XRCamera3D" type="XRCamera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.7, 0)
+cull_mask = 1048571
 
 [node name="Neck" type="Node3D" parent="XRCamera3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.1, 0.1)

--- a/player_rigs/xrt2_static_player_rig.tscn
+++ b/player_rigs/xrt2_static_player_rig.tscn
@@ -7,6 +7,7 @@
 script = ExtResource("1_v7cup")
 
 [node name="XRCamera3D" type="XRCamera3D" parent="."]
+cull_mask = 1048571
 
 [node name="Fade" parent="XRCamera3D" instance=ExtResource("2_0btq6")]
 message = "Please recenter your tracking space."

--- a/shaders/shaded_no_alpha.gdshader
+++ b/shaders/shaded_no_alpha.gdshader
@@ -1,0 +1,15 @@
+// Simple unshaded color with alpha output
+
+shader_type spatial;
+
+uniform vec4 albedo : source_color = vec4(1.0);
+uniform float metallic : hint_range(0.0, 1.0, 0.1) = 0.0;
+uniform float roughness : hint_range(0.0, 1.0, 0.1) = 1.0;
+uniform float specular : hint_range(0.0, 1.0, 0.1) = 0.5;
+
+void fragment() {
+	ALBEDO = albedo.rgb;
+	METALLIC = metallic;
+	ROUGHNESS = roughness;
+	SPECULAR = specular;
+}

--- a/shaders/shaded_no_alpha.gdshader.uid
+++ b/shaders/shaded_no_alpha.gdshader.uid
@@ -1,0 +1,1 @@
+uid://xrt2oqik7ik

--- a/shaders/unshaded_no_alpha.gdshader
+++ b/shaders/unshaded_no_alpha.gdshader
@@ -1,0 +1,10 @@
+// Simple unshaded color with alpha output
+
+shader_type spatial;
+render_mode unshaded;
+
+uniform vec4 albedo : source_color = vec4(1.0);
+
+void fragment() {
+	ALBEDO = albedo.rgb;
+}

--- a/shaders/unshaded_no_alpha.gdshader.uid
+++ b/shaders/unshaded_no_alpha.gdshader.uid
@@ -1,0 +1,1 @@
+uid://xrt2so02d7k

--- a/shaders/unshaded_texture_no_alpha.gdshader
+++ b/shaders/unshaded_texture_no_alpha.gdshader
@@ -1,0 +1,19 @@
+// Simple unshaded texture with alpha output
+
+shader_type spatial;
+render_mode unshaded;
+
+uniform vec4 albedo : source_color = vec4(1.0);
+uniform sampler2D texture_albedo : source_color,filter_linear,repeat_disable;
+
+uniform vec2 uv_scale = vec2(1.0);
+uniform vec2 uv_offset = vec2(0.0);
+
+void vertex() {
+	UV = UV * uv_scale + uv_offset;
+}
+
+void fragment() {
+	vec4 albedo_tex = texture(texture_albedo,UV);
+	ALBEDO = albedo.rgb * albedo_tex.rgb;
+}

--- a/shaders/unshaded_texture_no_alpha.gdshader.uid
+++ b/shaders/unshaded_texture_no_alpha.gdshader.uid
@@ -1,0 +1,1 @@
+uid://xrt2lfbdmdk

--- a/staging/xrt2_staging.tscn
+++ b/staging/xrt2_staging.tscn
@@ -17,6 +17,7 @@ script = ExtResource("1_ap58f")
 
 [node name="XRCamera3D" type="XRCamera3D" parent="Player/XROrigin3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.8, 0)
+cull_mask = 1048571
 environment = ExtResource("3_7oin8")
 
 [node name="LeftHand" type="XRController3D" parent="Player/XROrigin3D"]


### PR DESCRIPTION
This adds the basic setup to allow, on PCVR, for the desktop to show a separate view from what the player sees inside of the headset. For now this only supports a spectator camera.

When enabled the player can optionally see the camera in their view with a preview of what is being recorded. Ideal when you want to record what you're doing but from an outside view.

Here is the view from inside of the headset:
https://github.com/user-attachments/assets/83e28c32-4814-44ff-9977-e796fa95c44b

Right now the camera is static but I do plan follow up PRs to make the camera moveable, or have other options like a stabilized camera from the players POV.