### PR TITLE
Add a stabilized camera option for our construct setup

### DIFF
--- a/construct/xrt2_spectator_camera.gd
+++ b/construct/xrt2_spectator_camera.gd
@@ -45,6 +45,10 @@ var _viewport_texture : ViewportTexture
 # Display on which we show our viewport image
 @onready var _display : MeshInstance3D = $SpectatorCamera3D/Camera/CameraDisplay/Display
 
+## Make this camera current
+func make_current():
+	$SpectatorCamera3D.current = true
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/construct/xrt2_stabilized_camera.gd
+++ b/construct/xrt2_stabilized_camera.gd
@@ -1,0 +1,54 @@
+#-------------------------------------------------------------------------------
+# xrt2_stabilized_camera.gd
+#-------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2024-present Bastiaan Olij, Malcolm A Nixon and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#-------------------------------------------------------------------------------
+
+class_name XRT2StabilizedCamera
+extends Node3D
+
+@export_range(0.01, 1.0, 0.01) var weight = 0.08
+
+var previous_transform : Transform3D
+
+## Make this camera current
+func make_current():
+	$StabilizedCamera3D.current = true
+
+# Position for our player
+func _process(delta):
+	var camera_tracker : XRPositionalTracker = XRServer.get_tracker("head")
+	if camera_tracker:
+		var pose : XRPose = camera_tracker.get_pose("default")
+		if pose and pose.has_tracking_data:
+			var camera_transform = pose.get_adjusted_transform()
+			camera_transform = camera_transform.looking_at(camera_transform.origin - camera_transform.basis.z)
+			camera_transform.origin += camera_transform.basis.z * 0.01
+
+			if (camera_transform.origin - previous_transform.origin).length() < 0.5:
+				# Stabilize logic
+				camera_transform = previous_transform.interpolate_with(camera_transform, weight)
+
+
+			$StabilizedCamera3D.global_transform = XRServer.world_origin * camera_transform
+			previous_transform = camera_transform

--- a/construct/xrt2_stabilized_camera.gd.uid
+++ b/construct/xrt2_stabilized_camera.gd.uid
@@ -1,0 +1,1 @@
+uid://xrt23dlfj0r

--- a/construct/xrt2_stabilized_camera.tscn
+++ b/construct/xrt2_stabilized_camera.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://xrt27oxtswc"]
+
+[ext_resource type="Script" uid="uid://xrt23dlfj0r" path="res://addons/godot-xr-tools2/construct/xrt2_stabilized_camera.gd" id="1_0aj8h"]
+
+[node name="Xrt2StabilizedCamera" type="Node3D"]
+script = ExtResource("1_0aj8h")
+
+[node name="StabilizedCamera3D" type="Camera3D" parent="."]
+top_level = true
+cull_mask = 1048573

--- a/hands/xrt2_collision_hand.gd
+++ b/hands/xrt2_collision_hand.gd
@@ -197,6 +197,7 @@ var _hand_tracker : XRHandTracker
 var _hand_skeleton : Skeleton3D
 var _controller_tracker : XRControllerTracker
 var _pickup : XRT2Pickup
+var _parent_body : CollisionObject3D
 
 # Sorted stack of TargetOverride
 var _target_overrides : Array[TargetOverride]
@@ -445,11 +446,11 @@ func _ready():
 	top_level = true
 	process_physics_priority = -90
 
-	var parent : CollisionObject3D = get_collision_parent()
-	if parent:
+	_parent_body = get_collision_parent()
+	if _parent_body:
 		# Hands shouldn't collide with a parent collision object
-		add_collision_exception_with(parent)
-		parent.add_collision_exception_with(self)
+		add_collision_exception_with(_parent_body)
+		_parent_body.add_collision_exception_with(self)
 
 	# If we have a pickup function, get it
 	_pickup = XRT2Pickup.get_pickup(self)


### PR DESCRIPTION
Add a stabilized camera option for spectators. This is a camera that is positioned at the players head but removes the z rotation and smooths the motion. This is a nicer view for recording things from the players point of view without minor head movement making the recording iffy.