### PR TITLE
Introduce an hand pose node

### DIFF
--- a/hands/xrt2_collision_hand.gd
+++ b/hands/xrt2_collision_hand.gd
@@ -31,11 +31,9 @@ extends RigidBody3D
 
 ## XRTools2 Collision Hand Container Script
 ##
-## This script implements logic for collision hands. Specifically it tracks
-## its ancestor [XRController3D], and can act as a container for hand models
-## and pickup functions.
-##
-## Note: This works best when used with the palm-pose pose.
+## This script implements logic for collision hands.
+## It encompasses all logic for showing an articulated hand mesh,
+## handles its animations, and most importantly, collisions.
 
 #region Signals
 ## Emitted when a new hand mesh was loaded
@@ -346,6 +344,24 @@ func get_concatenated_bone_names() -> String:
 
 	return skeleton.get_concatenated_bone_names()
 
+## Get the transform for the given pose action of the normal tracker
+func get_pose_transform(pose_action : String) -> Transform3D:
+	if _controller_tracker and _hand_tracker:
+		var hand_pose : XRPose = _hand_tracker.get_pose("default")
+		var controller_pose : XRPose = _controller_tracker.get_pose(pose_action)
+		if controller_pose:
+			if hand_pose:
+				# Use our hand controller pose
+
+				# Don't need to do this on our adjusted transforms, just cancels eachother out
+				return hand_pose.get_transform().inverse() * controller_pose.get_transform()
+			elif fallback_pose_action != pose_action:
+				# Use our fallback pose?
+				var fallback_pose : XRPose = _controller_tracker.get_pose(fallback_pose_action)
+				if fallback_pose:
+					return fallback_pose.get_transform().inverse() * controller_pose.get_transform()
+
+	return Transform3D()
 
 ## Get the transform of the given bone local to our collision hand
 func get_bone_transform(bone_name : String) -> Transform3D:

--- a/hands/xrt2_hand_pose.gd.uid
+++ b/hands/xrt2_hand_pose.gd.uid
@@ -1,0 +1,1 @@
+uid://xrt2i05y2cx

--- a/player_rigs/interaction_functions/xrt2_pickup.gd
+++ b/player_rigs/interaction_functions/xrt2_pickup.gd
@@ -51,6 +51,16 @@ extends Node3D
 #   automatically pose the hand correctly if no grab point is specified.
 # - Need to re-introduce grab points with optional finger poses
 
+#region Signals
+
+## Inform that this hand has picked up this object (also if this is the second hand).
+signal picked_up(by : XRT2Pickup, what : PhysicsBody3D)
+
+## Inform that this hand has dropped this object (also if this object is still held by the other hand).
+signal dropped(by : XRT2Pickup, what : PhysicsBody3D)
+
+#endregion
+
 # Class for storing our highlight overrule data
 class HighlightedBody extends RefCounted:
 	var original_materials : Dictionary[MeshInstance3D, Material]
@@ -323,6 +333,9 @@ func pickup_object(which : PhysicsBody3D):
 
 	# TODO set pose overrule based on what we've picked up (if applicable)
 
+	# Send out a signal to let those wanting to know that we picked something up
+	picked_up.emit(self, _picked_up)
+
 	# Let object know that we picked it up
 	if _is_primary and _picked_up.has_method("picked_up"):
 		_picked_up.picked_up(self)
@@ -387,6 +400,10 @@ func drop_held_object( \
 
 		if was_picked_up.has_method("dropped"):
 			was_picked_up.dropped(self)
+
+	# Send out a signal to let those wanting to know that we dropped something
+	dropped.emit(self, was_picked_up)
+
 #endregion
 
 


### PR DESCRIPTION
This PR introduces a new child node for collision hands that allows us to use action poses such as the aim, grip and palm pose and position them in correct relationship of the collision hands.

This means these poses are also correctly adjusted when collision hands encounter colliders.