### PR TITLE
Improve pickup placement

### DIFF
--- a/debug/xrt2_vector.gd
+++ b/debug/xrt2_vector.gd
@@ -39,6 +39,13 @@ extends Node3D
 		if is_inside_tree():
 			_on_layers_changed()
 
+func place_vector(at: Vector3, direction: Vector3):
+	if abs(Vector3.UP.dot(at)) < 0.9:
+		transform = Transform3D(Basis.looking_at(direction, Vector3.UP, true), at)
+	else:
+		transform = Transform3D(Basis.looking_at(direction, Vector3.RIGHT, true), at)
+
+
 func _on_color_changed():
 	var material : StandardMaterial3D = $Stem.material_override
 	material.albedo_color = color


### PR DESCRIPTION
We're now using `get_rest_info` to detect the closest object and use its point and normal result to place the hand properly on the object we're touching.

This also disables grabbing an object that is above the hand.

Implements #67

Note: work done on stream 27/02/2026 for anyone who wants more detail