### PR TITLE
Implement collision exception handler

### DIFF
--- a/player/interaction_functions/xrt2_pickup.gd
+++ b/player/interaction_functions/xrt2_pickup.gd
@@ -296,10 +296,7 @@ func pickup_object(object : GrabObject):
 
 	if object.body is RigidBody3D or object.body is PhysicalBone3D:
 		# Make sure our body doesn't collide with things we've picked up
-		if _is_primary and _xr_player_object:
-			# TODO should create a collision exception manager to ensure we don't undo this too quickly
-			object.body.add_collision_exception_with(_xr_player_object)
-			_xr_player_object.add_collision_exception_with(object.body)
+		XRT2Helper.add_collision_exception(_xr_player_object, object.body)
 
 		# Get some behaviour characteristics
 		var rigid_body_behaviour: XRT2RigidBodyBehaviour = XRT2RigidBodyBehaviour.get_behaviour_node(object.body)
@@ -319,8 +316,7 @@ func pickup_object(object : GrabObject):
 
 	if _xr_collision_hand:
 		# Make a collision exception between hand and picked up object
-		_picked_up.add_collision_exception_with(_xr_collision_hand)
-		_xr_collision_hand.add_collision_exception_with(_picked_up)
+		XRT2Helper.add_collision_exception(_xr_collision_hand, _picked_up)
 
 	# Find our grab point (if any).
 	# Note, we're already handled our exclusive logic, can ignore that here.
@@ -381,9 +377,7 @@ func drop_held_object( \
 
 	# Process letting go
 	if _xr_collision_hand:
-		# TODO: Delay this until we're not colliding!
-		_picked_up.remove_collision_exception_with(_xr_collision_hand)
-		_xr_collision_hand.remove_collision_exception_with(_picked_up)
+		XRT2Helper.remove_collision_exception(_xr_collision_hand, _picked_up)
 
 		_xr_collision_hand.remove_target_override(_picked_up)
 		_xr_collision_hand.finger_poses = null
@@ -403,20 +397,17 @@ func drop_held_object( \
 	_pivot_on_primary = false
 	_grab_as_static_body = false
 
+	if _xr_player_object and (was_picked_up is RigidBody3D or was_picked_up is PhysicalBone3D):
+		XRT2Helper.remove_collision_exception(_xr_player_object, was_picked_up)
+
 	var other = picked_up_by(was_picked_up)
 	if other:
 		# If it isn't already primary, this is now our primary
 		other._is_primary = true
 		other._two_hand_delay = two_hand_delay
 		other._picked_up_to_org_target = was_picked_up.global_transform.inverse() * other.get_controller_target()
-	elif _xr_player_object:
-		if was_picked_up is RigidBody3D or was_picked_up is PhysicalBone3D:
-			# TODO: Delay this until we're not colliding!
-			was_picked_up.remove_collision_exception_with(_xr_player_object)
-			_xr_player_object.remove_collision_exception_with(was_picked_up)
-
-		if was_picked_up.has_method("dropped"):
-			was_picked_up.dropped(self)
+	elif _xr_player_object and was_picked_up.has_method("dropped"):
+		was_picked_up.dropped(self)
 
 	# Send out a signal to let those wanting to know that we dropped something
 	dropped.emit(self, was_picked_up)

--- a/xrt2_helper.gd
+++ b/xrt2_helper.gd
@@ -205,9 +205,161 @@ static func apply_torque_to_target(
 
 
 ################################################################################
-## Note, older PD related code below is unused but kept for reference
+# Helper functions to track collision exceptions.
+# Note: We should only ever have a few collision exceptions in play
+# at any given time, so looping an array is fine.
+
+class CollisionExceptionPair:
+	var bodyA: PhysicsBody3D
+	var bodyB: PhysicsBody3D
+	var count: int
+	var registered: bool
+
+static var _collision_exception_pairs: Array[CollisionExceptionPair]
+static var _collision_check_timer: Timer
+static var _collision_check_wait_time: float = 0.1
+
+
+## Set how often we check collisions for our released collision exceptions.
+static func set_collision_check_update_rate(times_per_second: float):
+	if times_per_second <= 0.0:
+		return
+
+	_collision_check_wait_time = 1.0 / times_per_second
+	if _collision_check_timer:
+		_collision_check_timer.wait_time = _collision_check_wait_time
+
+
+# Check our collision exception array for a physics body pair
+static func _find_collision_exception_pair(bodyA: PhysicsBody3D, bodyB: PhysicsBody3D, add_if_missing: bool = true) -> CollisionExceptionPair:
+	for cep in _collision_exception_pairs:
+		if cep.bodyA == bodyA and cep.bodyB == bodyB:
+			return cep
+
+		if cep.bodyA == bodyB and cep.bodyB == bodyA:
+			return cep
+
+	if add_if_missing:
+		var cep: CollisionExceptionPair = CollisionExceptionPair.new()
+		cep.bodyA = bodyA
+		cep.bodyB = bodyB
+		cep.count = 0
+		cep.registered = false
+		_collision_exception_pairs.push_back(cep)
+		return cep
+	else:
+		return null
+
+
+# Our timer function to check if we can remove collision exceptions.
+static func _on_collision_check_timer():
+	# We loop a copy so we can modify the original
+	var pairs: Array[CollisionExceptionPair] = _collision_exception_pairs
+
+	for cep in pairs:
+		if not is_instance_valid(cep.bodyA) or not is_instance_valid(cep.bodyB):
+			# No longer valid, probably because our scene was unloaded.
+			# Collision exceptions are no longer active so just erase.
+			_collision_exception_pairs.erase(cep)
+		elif cep.count == 0:
+			# Check if bodyA and bodyB are no longer colliding and if so,
+			# remove collisions and free.
+			var is_colliding: bool = false
+			var body_state: PhysicsDirectBodyState3D = PhysicsServer3D.body_get_direct_state(cep.bodyA.get_rid())
+			var space_state: PhysicsDirectSpaceState3D = body_state.get_space_state()
+			var query: PhysicsShapeQueryParameters3D = PhysicsShapeQueryParameters3D.new()
+
+			# Temporarily set a unique layer for bodyB,
+			# so we're only checking collisions with bodyB.
+			# We user layer 32 assuming nobody uses that :)
+			var was_bodyB_layer = cep.bodyB.collision_layer
+			cep.bodyB.collision_layer = 1 << 31
+
+			# Setup our query 
+			query.collision_mask = 1 << 31
+
+			# Check for collisions
+			for owner_id in cep.bodyA.get_shape_owners():
+				query.transform = cep.bodyA.global_transform * cep.bodyA.shape_owner_get_transform(owner_id)
+
+				for shape_id in cep.bodyA.shape_owner_get_shape_count(owner_id):
+					var shape: Shape3D = cep.bodyA.shape_owner_get_shape(owner_id, shape_id)
+					query.shape = shape
+
+					var info: PackedVector3Array = space_state.collide_shape(query, 1)
+					if not info.is_empty():
+						is_colliding = true
+						break
+
+				if is_colliding:
+					break
+
+			# Reset our bodyB layer to what it was.
+			cep.bodyB.collision_layer = was_bodyB_layer
+
+			# If we are no longer colliding, time to free.
+			if not is_colliding:
+				cep.bodyA.remove_collision_exception_with(cep.bodyB)
+				cep.bodyB.remove_collision_exception_with(cep.bodyA)
+				_collision_exception_pairs.erase(cep)
+
+	# If we have nothing left to check, don't need to keep our timer running.
+	if _collision_check_timer and _collision_exception_pairs.is_empty():
+		_collision_check_timer.stop()
+
+## Add a collision exception between these two physics bodies.
+## If a collision exception was already created, we refcount this.
+static func add_collision_exception(bodyA: PhysicsBody3D, bodyB: PhysicsBody3D):
+	var cep: CollisionExceptionPair = _find_collision_exception_pair(bodyA, bodyB)
+
+	# If new entry we add our collision exceptions
+	if not cep.registered:
+		bodyA.add_collision_exception_with(bodyB)
+		bodyB.add_collision_exception_with(bodyA)
+		cep.registered = true
+
+	cep.count = cep.count + 1
+
+	# First time? Create our collision timer on our root.
+	if not _collision_check_timer:
+		var scene_tree: SceneTree = bodyA.get_tree()
+		var root: Node = scene_tree.get_root()
+
+		_collision_check_timer = Timer.new()
+		_collision_check_timer.name = "CollisionCheckTimer"
+		_collision_check_timer.wait_time = _collision_check_wait_time
+		root.add_child(_collision_check_timer)
+
+		_collision_check_timer.timeout.connect(_on_collision_check_timer)
+
+	# And start our timer.
+	if _collision_check_timer and _collision_check_timer.is_stopped():
+		_collision_check_timer.start()
+
+
+## Remove a collision exception between these two physics bodies.
+## The collision exception is only removed if we've called this for
+## each time [add_collision_exception] was called AND the two
+## bodies no longer collide.
+static func remove_collision_exception(bodyA: PhysicsBody3D, bodyB: PhysicsBody3D):
+	var cep: CollisionExceptionPair = _find_collision_exception_pair(bodyA, bodyB, false)
+	if not cep:
+		return
+
+	if cep.count == 0:
+		push_warning("Called remove_collision_exception without matching add_collision_exception")
+		return
+
+	cep.count = cep.count - 1
+	# Note: Once this hits 0, it will be freed in our timer when
+	# we no longer collide.
+
+
+################################################################################
+# Note, older PD related code below is unused but kept for reference
 
 ## Apply a linear force to a RigidBody based on a target location
+## @deprecated old PID based physics code
 static func apply_linear_force(
 		delta : float,
 		apply_to: RigidBody3D,
@@ -256,6 +408,7 @@ static func apply_linear_force(
 
 
 ## Apply a torque force to a RigidBody based on a target orientation
+## @deprecated old PID based physics code
 static func apply_torque(
 		delta : float,
 		apply_to: RigidBody3D,


### PR DESCRIPTION
When we grab objects we can be in a situation where our hands slightly clip the object we're holding, or in the situation of a rigidbody, we could unintentionally collide with our players body.

For this reason we create collision exceptions between the held object and the hand and, if applicable, player body.

This causes an issue when the player drops the held object while such collisions are active as the ensuing collision can propel the player away from the dropped object.

This PR introduces managing logic inside of the `XRT2Helper` class that tracks the collision exceptions. When the player releases an object, instead of immediately removing the collision exception, we will check for collisions until it is safe to remove the exception.

In a two handed situation it is possible that the exception between picked up object and player body is registered from both hands, this solution thus also has a refcount on the exceptions only removing this collision exception when both hands have dropped the object.

Fixes #71